### PR TITLE
Fix scope issue for php 5.3.x

### DIFF
--- a/wp-lazysizes.php
+++ b/wp-lazysizes.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'LazySizes' ) ) :
                 add_filter( 'post_thumbnail_html', array( __CLASS__, '_filter_images' ), 200 );
                 add_filter( 'widget_text', array( __CLASS__, '_filter_images' ), 200 );
                 add_filter( 'get_avatar', function($content){
-                    return self::_filter_images($content, 'noratio');
+                    return LazySizes::_filter_images($content, 'noratio');
                 }, 200 );
             }
         }


### PR DESCRIPTION
Fixes "Fatal error: Cannot access self:: when no class scope is active in .../wp-content/plugins/wp-lazysizes/wp-lazysizes.php on line 47"
