### PR TITLE
Minor fix: 'load after Onload' selectbox option not retaining selected setting

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -115,7 +115,7 @@ function lazysizes_preloadAfterLoad(  ) {
     <select name='lazysizes_settings[preloadAfterLoad]'>
         <option value='false' <?php selected( $options['preloadAfterLoad'], 'false' ); ?>>Off</option>
         <option value='true' <?php selected( $options['preloadAfterLoad'], 'true' ); ?>>On</option>
-        <option value='smart' <?php selected( $options['preloadAfterLoad'], 2 ); ?>>Smart (desktop - on, mobile - off)</option>
+        <option value='smart' <?php selected( $options['preloadAfterLoad'], 'smart' ); ?>>Smart (desktop - on, mobile - off)</option>
     </select>
 <?php
 


### PR DESCRIPTION
Minor bug fix. The plugin's settings page now shows the correct default option in the 'load after Onload' selectbox. Previously it was reverting to showing the 'Off' option each time you visit the page, even though it had correctly changed the setting in the database.
